### PR TITLE
Fix typo in iterateAllCards

### DIFF
--- a/classes/Board.js
+++ b/classes/Board.js
@@ -69,7 +69,7 @@ class Board {
     
     *iterateAllCards(callbackFn, context) {        
         for (let l of yield* this.getLists()) {
-            for (let c of yield* this.getCards()) {
+            for (let c of yield* l.getCards()) {
                 callbackFn.call(context, c);
             }
         }


### PR DESCRIPTION
`this` should have been `l` when pulling the cards out of the lists on the board.
